### PR TITLE
Refactor HTML tag structure and add new classes

### DIFF
--- a/src/HtmlBuilder/HtmlBuilder.csproj
+++ b/src/HtmlBuilder/HtmlBuilder.csproj
@@ -15,13 +15,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Tags\NewFolder\**" />
-    <EmbeddedResource Remove="Tags\NewFolder\**" />
-    <None Remove="Tags\NewFolder\**" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.36" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.36" />
+    <Folder Include="Tags\Interactive Tags\" />
+    <Folder Include="Tags\Form Tags\" />
+    <Folder Include="Tags\Styling Tags\" />
+    <Folder Include="Tags\Table Tags\" />
+    <Folder Include="Tags\Script and Meta Tags\" />
+    <Folder Include="Tags\Text Content Tags\" />
+    <Folder Include="Tags\Media Tags\" />
   </ItemGroup>
 
 </Project>

--- a/src/HtmlBuilder/Tags/Html.cs
+++ b/src/HtmlBuilder/Tags/Html.cs
@@ -1,9 +1,0 @@
-﻿
-namespace HtmlBuilder.Tags;
-
-public class Html : DoubleTagWithChildren
-{
-    public Html() : base("html")
-    {
-    }
-}

--- a/src/HtmlBuilder/Tags/Structural Tags/Article.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Article.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Article : DoubleTagWithChildren
+    {
+        public Article() : base("article")
+        { 
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Aside.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Aside.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Aside : DoubleTagWithChildren
+    {
+        public Aside() : base("aside") 
+        {
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Body.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Body.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Body : DoubleTagWithChildren
+    {
+        public Body() : base("body")
+        {
+        }
+
+        public Body SetOnLoad(string script)
+        {
+            AddAttribute("onload", script);
+            return this;
+        }
+
+        public Body SetOnUnload(string script)
+        {
+            AddAttribute("onunload" , script); 
+            return this;
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Div.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Div.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Div : DoubleTagWithChildren
+    {
+        public Div() : base("div")
+        {
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Footer.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Footer.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Footer :DoubleTagWithChildren
+    {
+        public Footer() : base("footer")
+        { 
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Head.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Head.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Head : DoubleTagWithChildren
+    {
+        public Head() : base("head")
+        {
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Header.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Header.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Header : DoubleTagWithChildren
+    {
+        public Header() : base("header") 
+        {
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Html.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Html.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Html : DoubleTagWithChildren
+    {
+        public Html() : base("html")
+        {
+        }
+
+        public Html SetLang(string lang)
+        {
+            AddAttribute("lang" , lang);
+            return this;
+        }
+
+        public Html SetMainfest(string mainfestUrl)
+        {
+            AddAttribute("mainfest", mainfestUrl);
+            return this;
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Main.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Main.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Main : DoubleTagWithChildren
+    {
+        public Main() : base("main")
+        {
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Nav.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Nav.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Nav : DoubleTagWithChildren
+    {
+        public Nav() : base("nav")
+        { 
+        }
+    }
+}

--- a/src/HtmlBuilder/Tags/Structural Tags/Section.cs
+++ b/src/HtmlBuilder/Tags/Structural Tags/Section.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlBuilder.Tags.Structural_Tags
+{
+    public class Section : DoubleTagWithChildren
+    {
+        public Section() : base("section")
+        {
+        }
+    }
+}


### PR DESCRIPTION
Updated `HtmlBuilder.csproj` to remove `Tags\NewFolder` and added multiple tag folders. Introduced new classes for HTML structural tags: `Article`, `Aside`, `Body`, `Div`, `Footer`, `Head`, `Header`, `Main`, `Nav`, and `Section`. Enhanced the `Html` class with methods for `lang` and `mainfest` attributes.