### PR TITLE
Add new classes and enums for HTML elements

### DIFF
--- a/src/HtmlBuilder/ATarget.cs
+++ b/src/HtmlBuilder/ATarget.cs
@@ -1,9 +1,9 @@
-namespace HtmlBuilder;
+﻿namespace HtmlBuilder;
 
 /// <summary>
 /// Specifies where to open the linked document when the anchor (&lt;a&gt;) element is clicked.
 /// </summary>
-public enum AnchorTarget
+public enum ATarget
 {
     /// <summary>
     /// Opens the link in the same frame or tab. (default)

--- a/src/HtmlBuilder/ButtonType.cs
+++ b/src/HtmlBuilder/ButtonType.cs
@@ -1,0 +1,9 @@
+﻿namespace HtmlBuilder;
+
+public enum ButtonType
+{
+    Button,
+    Submit,
+    Reset,
+    Menu
+}

--- a/src/HtmlBuilder/Enums/BaseTarget.cs
+++ b/src/HtmlBuilder/Enums/BaseTarget.cs
@@ -1,11 +1,8 @@
-﻿namespace HtmlBuilder;
+﻿namespace HtmlBuilder.Enums;
 
-/// <summary>
-/// Specifies where to open the linked document when the anchor (&lt;a&gt;) element is clicked.
-/// </summary>
-public enum ATarget
+public enum BaseTarget
 {
-    /// <summary>
+     /// <summary>
     /// Opens the link in the same frame or tab. (default)
     /// </summary>
     _Self,

--- a/src/HtmlBuilder/Enums/FormEncType.cs
+++ b/src/HtmlBuilder/Enums/FormEncType.cs
@@ -1,0 +1,22 @@
+﻿namespace HtmlBuilder.Enums;
+
+/// <summary>
+/// Specifies the encoding type to use when submitting the form.
+/// </summary>
+public enum FormEnctype
+{
+    /// <summary>
+    /// 'application/x-www-form-urlencoded' is the default encoding type, used to encode form data.
+    /// </summary>
+    UrlEncoded,
+
+    /// <summary>
+    /// 'multipart/form-data' is used for forms that include file uploads.
+    /// </summary>
+    Multipart,
+
+    /// <summary>
+    /// 'text/plain' is a simple text encoding, used for debugging or sending plain data.
+    /// </summary>
+    PlainText
+}

--- a/src/HtmlBuilder/Enums/FormMethod.cs
+++ b/src/HtmlBuilder/Enums/FormMethod.cs
@@ -1,0 +1,18 @@
+﻿namespace HtmlBuilder.Enums;
+
+/// <summary>
+/// Specifies the HTTP method to use when submitting the form.
+/// </summary>
+public enum FormMethod
+{
+    /// <summary>
+    /// The GET method sends form data in the URL.
+    /// </summary>
+    Get,
+
+    /// <summary>
+    /// The POST method sends form data in the request body.
+    /// </summary>
+    Post
+}
+

--- a/src/HtmlBuilder/Enums/FormTarget.cs
+++ b/src/HtmlBuilder/Enums/FormTarget.cs
@@ -1,9 +1,9 @@
-﻿namespace HtmlBuilder;
+﻿namespace HtmlBuilder.Enums;
 
 /// <summary>
-/// Specifies where to open the linked document when the anchor (&lt;a&gt;) element is clicked.
+/// Specifies where to open the response when the form is submitted.
 /// </summary>
-public enum ATarget
+public enum FormTarget
 {
     /// <summary>
     /// Opens the link in the same frame or tab. (default)

--- a/src/HtmlBuilder/HtmlBuilder.csproj
+++ b/src/HtmlBuilder/HtmlBuilder.csproj
@@ -21,10 +21,6 @@
 
 
   <ItemGroup>
-    <Folder Include="Tags\FormTags\" />
-    <Folder Include="Enums\" />
-    <Folder Include="Tags\ScriptAndMetaTags\" />
-    <Folder Include="Tags\TableTags\" />
     <Folder Include="Utility\Extensions\NewFolder\" />
   </ItemGroup>
 

--- a/src/HtmlBuilder/HtmlBuilder.csproj
+++ b/src/HtmlBuilder/HtmlBuilder.csproj
@@ -23,10 +23,7 @@
   <ItemGroup>
     <Folder Include="Tags\FormTags\" />
     <Folder Include="Enums\" />
-    <Folder Include="Tags\InteractiveTags\" />
-    <Folder Include="Tags\MediaTags\" />
     <Folder Include="Tags\ScriptAndMetaTags\" />
-    <Folder Include="Tags\StylingTags\" />
     <Folder Include="Tags\TableTags\" />
     <Folder Include="Utility\Extensions\NewFolder\" />
   </ItemGroup>

--- a/src/HtmlBuilder/Tags/FormTags/Datalist.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Datalist.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.FormTags;
+
+public class Datalist() : DoubleTagWithChildren("datalist");

--- a/src/HtmlBuilder/Tags/FormTags/Fieldset.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Fieldset.cs
@@ -1,0 +1,29 @@
+﻿namespace HtmlBuilder.Tags.FormTags;
+
+public class Fieldset() : DoubleTagWithChildren("fieldset")
+{
+    public string FieldsetName { get; set; } = string.Empty;
+    public string Form { get; private set; } = string.Empty;
+    public bool IsDisabled { get; private set; } = false;
+
+    public Fieldset SetName(string name)
+    {
+        this.FieldsetName = name;
+        this.AddAttribute("name", name);
+        return this;
+    }
+
+    public Fieldset SetForm(string form)
+    {
+        this.Form = form;
+        this.AddAttribute("form", form);
+        return this;
+    }
+
+    public Fieldset SetDisabled()
+    {
+        this.IsDisabled = true;
+        this.AddAttribute("disabled");
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/FormTags/Form.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Form.cs
@@ -1,0 +1,47 @@
+﻿using HtmlBuilder.Enums;
+
+namespace HtmlBuilder.Tags.FormTags;
+public class Form() : DoubleTagWithChildren("form")
+{
+    public string Action { get; private set; } = string.Empty;
+    public FormMethod Method { get; private set; } = FormMethod.Get;
+    public FormEnctype Enctype { get; private set; } = FormEnctype.UrlEncoded;
+    public FormTarget Target { get; private set; } = FormTarget._Self;
+    public bool NoValidate { get; private set; } = false;
+
+    public Form SetAction(string action)
+    {
+        this.Action = action;
+        this.AddAttribute("action", action);
+        return this;
+    }
+
+    public Form SetMethod(FormMethod method)
+    {
+        this.Method = method;
+        this.AddAttribute("method", method.ToString().ToLower());
+        return this;
+    }
+
+    public Form SetEnctype(FormEnctype enctype)
+    {
+        this.Enctype = enctype;
+        this.AddAttribute("enctype", enctype.ToString().ToLower());
+        return this;
+    }
+
+    public Form SetTarget(FormTarget target)
+    {
+        this.Target = target;
+        this.AddAttribute("target", target.ToString().ToLower());
+        return this;
+    }
+
+    public Form SetNoValidate()
+    {
+        this.NoValidate = true;
+        this.AddAttribute("novalidate");
+        return this;
+    }
+
+}

--- a/src/HtmlBuilder/Tags/FormTags/Input.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Input.cs
@@ -1,8 +1,13 @@
-
+﻿
 namespace HtmlBuilder.Tags.FormTags;
 public class Input() : SingleTag("input")
 {
-    public InputType Type { get; set; }
+    public InputType Type { get; private set; } = InputType.Text;
+    public string InputName { get; private set; } = string.Empty;
+    public string Value { get; private set; } = string.Empty;
+    public string Placeholder { get; private set; } = string.Empty;
+    public bool IsRequired { get; private set; } = false;
+    public bool IsDisabled { get; private set; } = false;
 
 
     public Input SetType(InputType type)
@@ -12,9 +17,38 @@ public class Input() : SingleTag("input")
         return this;
     }
 
-    public Input SetValue(string defaultValue)
+    public Input SetName(string name)
     {
-        this.AddAttribute("value", defaultValue);
+        this.InputName = name;
+        this.AddAttribute("name", name);
+        return this;
+    }
+
+    public Input SetValue(string Value)
+    {
+        this.Value = Value;
+        this.AddAttribute("value", Value);
+        return this;
+    }
+
+    public Input SetPlaceholder(string placeholder)
+    {
+        this.Placeholder = placeholder;
+        this.AddAttribute("placeholder", placeholder);
+        return this;
+    }
+
+    public Input SetRequired()
+    {
+        this.IsRequired = true;
+        this.AddAttribute("required");
+        return this;
+    }
+
+    public Input SetDisabled()
+    {
+        this.IsDisabled = true;
+        this.AddAttribute("disabled");
         return this;
     }
 

--- a/src/HtmlBuilder/Tags/FormTags/Label.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Label.cs
@@ -1,3 +1,13 @@
-namespace HtmlBuilder.Tags.FormTags;
+﻿namespace HtmlBuilder.Tags.FormTags;
 
-public class Label() : DoubleTagWithContent("label");
+public class Label() : DoubleTagWithContent("label")
+{
+    public string For { get; private set; } = string.Empty;
+
+    public Label SetFor(string @for)
+    {
+        this.For = @for;
+        this.AddAttribute("For", @for);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/FormTags/Legend.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Legend.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.FormTags;
+
+public class Legend() : DoubleTagWithContent("legend");

--- a/src/HtmlBuilder/Tags/FormTags/Option.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Option.cs
@@ -1,15 +1,30 @@
-namespace HtmlBuilder.Tags.FormTags;
+﻿namespace HtmlBuilder.Tags.FormTags;
 
 public class Option() : DoubleTagWithContent("option")
 {
-    public void SetSelected()
+    public string Value { get; private set; } = string.Empty;
+    public bool IsSelected { get; private set; } = false;
+    public bool IsDisabled { get; private set; } = false;
+
+    public Option SetValue(string value)
     {
-        this.AddAttribute("selected");
+        this.Value = value;
+        this.AddAttribute("value", value);
+        return this;
     }
 
-    public void SetValue(string value)
+    public Option SetSelected()
     {
-        this.AddAttribute("value", value);
+        this.IsSelected = true;
+        this.AddAttribute("selected");
+        return this;
+    }
+
+    public Option SetDisabled()
+    {
+        this.IsDisabled = true;
+        this.AddAttribute("disabled");
+        return this;
     }
 
     public string? GetAttribute(string key)

--- a/src/HtmlBuilder/Tags/FormTags/Output.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Output.cs
@@ -1,0 +1,20 @@
+﻿namespace HtmlBuilder.Tags.FormTags;
+
+public class Output() : DoubleTagWithContent("output")
+{
+    public string OutputName { get; private set; } = string.Empty;
+    public string For { get; private set; } = string.Empty;
+    public Output SetName(string name)
+    {
+        this.OutputName = name;
+        this.AddAttribute("name", name);
+        return this;
+    }
+
+    public Output SetForm(string @for)
+    {
+        this.For = @for;
+        this.AddAttribute("form", @for);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/FormTags/Select.cs
+++ b/src/HtmlBuilder/Tags/FormTags/Select.cs
@@ -1,6 +1,39 @@
-namespace HtmlBuilder.Tags.FormTags;
+﻿namespace HtmlBuilder.Tags.FormTags;
 public class Select() : DoubleTagWithChildren("select")
 {
+    public string SelectName { get; private set; } = string.Empty;
+    public bool IsRequired { get; private set; } = false;
+    public bool IsDisabled { get; private set; } = false;
+    public bool IsMultiple { get; private set; } = false;
+
+    public Select SetName(string name)
+    {
+        this.SelectName = name;
+        this.AddAttribute("name", name);
+        return this;
+    }
+
+    public Select SetRequired()
+    {
+        this.IsRequired = true;
+        this.AddAttribute("required");
+        return this;
+    }
+
+    public Select SetDisabled()
+    {
+        this.IsDisabled = true;
+        this.AddAttribute("disabled");
+        return this;
+    }
+
+    public Select SetMultiple()
+    {
+        this.IsMultiple = true;
+        this.AddAttribute("multiple");
+        return this;
+    }
+
     public void SetSelected(string value)
     {
         foreach (var child in this.Children.OfType<Option>())

--- a/src/HtmlBuilder/Tags/FormTags/TextArea.cs
+++ b/src/HtmlBuilder/Tags/FormTags/TextArea.cs
@@ -1,3 +1,53 @@
-namespace HtmlBuilder.Tags.FormTags;
+﻿namespace HtmlBuilder.Tags.FormTags;
 
-public class TextArea() : DoubleTagWithContent("textarea");
+public class Textarea() : DoubleTagWithContent("textarea")
+{
+    public string TextareaName { get; private set; } = string.Empty;
+    public string Placeholder { get; private set; } = string.Empty;
+    public int Rows { get; private set; } = 0;
+    public int Cols { get; private set; } = 0;
+    public bool IsRequired { get; private set; } = false;
+    public bool IsDisabled { get; private set; } = false;
+
+    public Textarea SetName(string name)
+    {
+        this.TextareaName = name;
+        this.AddAttribute("name", name);
+        return this;
+    }
+
+    public Textarea SetPlaceholder(string placeholder)
+    {
+        this.Placeholder = placeholder;
+        this.AddAttribute("placeholder", placeholder);
+        return this;
+    }
+
+    public Textarea SetRows(int rows)
+    {
+        this.Rows = rows;
+        this.AddAttribute("rows", rows.ToString());
+        return this;
+    }
+
+    public Textarea SetCols(int cols)
+    {
+        this.Cols = cols;
+        this.AddAttribute("cols", cols.ToString());
+        return this;
+    }
+
+    public Textarea SetRequired()
+    {
+        this.IsRequired = true;
+        this.AddAttribute("required");
+        return this;
+    }
+
+    public Textarea SetDisabled()
+    {
+        this.IsDisabled = true;
+        this.AddAttribute("disabled");
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/InteractiveTags/A.cs
+++ b/src/HtmlBuilder/Tags/InteractiveTags/A.cs
@@ -1,11 +1,11 @@
-namespace HtmlBuilder.Tags.InteractiveTags;
+﻿namespace HtmlBuilder.Tags.InteractiveTags;
 
 public class A() : DoubleTagWithContent("a")
 {
     public string Href { get; private set; } = string.Empty;
     public string Rel { get; private set; } = string.Empty;
     public string Type { get; private set; } = string.Empty;
-    public string Target { get; private set; } = string.Empty;
+    public ATarget Target { get; private set; } = ATarget._Self;
 
 
     public A SetHref(string href)
@@ -29,10 +29,10 @@ public class A() : DoubleTagWithContent("a")
         return this;
     }
 
-    public A SetTarget(string target)
+    public A SetTarget(ATarget target)
     {
         this.Target = target;
-        this.AddAttribute("target", target);
+        this.AddAttribute("target", target.ToString().ToLower());
         return this;
     }
 

--- a/src/HtmlBuilder/Tags/InteractiveTags/Button.cs
+++ b/src/HtmlBuilder/Tags/InteractiveTags/Button.cs
@@ -1,2 +1,29 @@
-namespace HtmlBuilder.Tags.InteractiveTags;
+﻿namespace HtmlBuilder.Tags.InteractiveTags;
 
+public class Button() : DoubleTagWithContent("button")
+{
+    public bool IsDisabled { get; private set; } = false;
+    public ButtonType Type { get; private set; } = ButtonType.Submit;
+    public string Value { get; private set; } = string.Empty;
+
+    public Button SetDisabled()
+    {
+        IsDisabled = true;
+        AddAttribute("disabled");
+        return this;
+    }
+
+    public Button SetType(ButtonType type)
+    {
+        Type = type;
+        AddAttribute("type", type.ToString().ToLower());
+        return this;
+    }
+
+    public Button SetValue(string value)
+    {
+        Value = value;
+        AddAttribute("value", value);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/InteractiveTags/Details.cs
+++ b/src/HtmlBuilder/Tags/InteractiveTags/Details.cs
@@ -1,0 +1,13 @@
+﻿namespace HtmlBuilder.Tags.InteractiveTags;
+
+public class Details() : DoubleTagWithChildren("details")
+{
+    public bool IsOpen { get; private set; } = false;
+
+    public Details SetOpen()
+    {
+        IsOpen = true;
+        AddAttribute("open");
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/InteractiveTags/Dialog.cs
+++ b/src/HtmlBuilder/Tags/InteractiveTags/Dialog.cs
@@ -1,0 +1,12 @@
+﻿namespace HtmlBuilder.Tags.InteractiveTags;
+
+public class Dialog() : DoubleTagWithChildren("dialog")
+{
+    public bool IsOpen { get; private set; } = false;
+    public Dialog SetOpen()
+    {
+        IsOpen = true;
+        AddAttribute("open");
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/InteractiveTags/Menu.cs
+++ b/src/HtmlBuilder/Tags/InteractiveTags/Menu.cs
@@ -1,0 +1,21 @@
+﻿namespace HtmlBuilder.Tags.InteractiveTags;
+
+public class Menu() : DoubleTagWithChildren("menu")
+{
+    public string Type { get; private set; } = string.Empty;
+    public string Label { get; private set; } = string.Empty;
+
+    public Menu SetType(string type)
+    {
+        Type = type;
+        AddAttribute("type", type);
+        return this;
+    }
+
+    public Menu SetLabel(string label)
+    {
+        Label = label;
+        AddAttribute("label", label);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/InteractiveTags/Summary.cs
+++ b/src/HtmlBuilder/Tags/InteractiveTags/Summary.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.InteractiveTags;
+
+public class Summary() : DoubleTagWithContent("summary");

--- a/src/HtmlBuilder/Tags/MediaTags/Audio.cs
+++ b/src/HtmlBuilder/Tags/MediaTags/Audio.cs
@@ -1,0 +1,45 @@
+﻿namespace HtmlBuilder.Tags.MediaTags;
+
+public class Audio() : DoubleTagWithChildren("audio")
+{
+    public string Src { get; private set; } = string.Empty;
+    public bool Controls { get; private set; } = false;
+    public bool Autoplay { get; private set; } = false;
+    public bool Loop { get; private set; } = false;
+    public bool Muted { get; private set; } = false;
+
+    public Audio SetSrc(string src)
+    {
+        this.Src = src;
+        this.AddAttribute("src", src);
+        return this;
+    }
+
+    public Audio SetControls()
+    {
+        this.Controls = true;
+        this.AddAttribute("controls");
+        return this;
+    }
+
+    public Audio SetAutoplay()
+    {
+        this.Autoplay = true;
+        this.AddAttribute("autoplay");
+        return this;
+    }
+
+    public Audio SetLoop()
+    {
+        this.Loop = true;
+        this.AddAttribute("loop");
+        return this;
+    }
+
+    public Audio SetMuted()
+    {
+        this.Muted = true;
+        this.AddAttribute("muted");
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/MediaTags/Iframe.cs
+++ b/src/HtmlBuilder/Tags/MediaTags/Iframe.cs
@@ -1,0 +1,46 @@
+﻿namespace HtmlBuilder.Tags.MediaTags;
+
+public class Iframe() : SingleTag("iframe")
+{
+    public string Src { get; private set; } = string.Empty;
+    public string Width { get; private set; }
+    public string Height { get; private set; }
+    public string Frameborder { get; private set; }
+    public bool AllowFullscreen { get; private set; } = false;
+
+    public Iframe SetSrc(string src)
+    {
+        Src = src;
+        AddAttribute("src", src);
+        return this;
+    }
+
+    public Iframe SetWidth(string width)
+    {
+        Width = width;
+        AddAttribute("width", width);
+        return this;
+    }
+
+    public Iframe SetHeight(string height)
+    {
+        Height = height;
+        AddAttribute("height", height);
+        return this;
+    }
+
+    public Iframe SetFrameborder(string frameborder)
+    {
+        Frameborder = frameborder;
+        AddAttribute("frameborder", frameborder);
+        return this;
+    }
+
+    public Iframe SetAllowFullscreen()
+    {
+        AllowFullscreen = true;
+        AddAttribute("allowfullscreen");
+        return this;
+    }
+}
+

--- a/src/HtmlBuilder/Tags/MediaTags/Img.cs
+++ b/src/HtmlBuilder/Tags/MediaTags/Img.cs
@@ -1,0 +1,38 @@
+﻿namespace HtmlBuilder.Tags.MediaTags;
+
+public class Img() : SingleTag("img")
+{
+    public string Src { get; private set; } = string.Empty;
+    public string Alt { get; private set; } = string.Empty;
+    public string Width { get; private set; }
+    public string Height { get; private set; }
+
+    public Img SetSrc(string src)
+    {
+        this.Src = src;
+        this.AddAttribute("src", src);
+        return this;
+    }
+
+    public Img SetAlt(string alt)
+    {
+        this.Alt = alt;
+        this.AddAttribute("alt", alt);
+        return this;
+    }
+
+    public Img SetWidth(string width)
+    {
+        this.Width = width;
+        this.AddAttribute("width", width);
+        return this;
+    }
+
+    public Img SetHeight(string height)
+    {
+        this.Height = height;
+        this.AddAttribute("height", height);
+        return this;
+    }
+
+}

--- a/src/HtmlBuilder/Tags/MediaTags/Source.cs
+++ b/src/HtmlBuilder/Tags/MediaTags/Source.cs
@@ -1,0 +1,20 @@
+﻿namespace HtmlBuilder.Tags.MediaTags;
+
+public class Source() : SingleTag("source")
+{
+    public string Src { get; private set; } = string.Empty;
+    public string Type { get; private set; } = string.Empty;
+
+    public Source SetSrc(string src)
+    {
+        this.Src = src;
+        this.AddAttribute("src", src);
+        return this;
+    }
+    public Source SetType(string type)
+    {
+        this.Type = type;
+        this.AddAttribute("type", type);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/MediaTags/Track.cs
+++ b/src/HtmlBuilder/Tags/MediaTags/Track.cs
@@ -1,0 +1,45 @@
+﻿namespace HtmlBuilder.Tags.MediaTags;
+
+public class Track() : SingleTag("track")
+{
+    public string Src { get; private set; } = string.Empty;
+    public TrackKind Kind { get; private set; } = TrackKind.Subtitles;
+    public string Srclang { get; private set; } = string.Empty;
+    public string Label { get; private set; } = string.Empty;
+    public bool IsDefault { get; private set; } = false;
+
+    public Track SetSrc(string src)
+    {
+        Src = src;
+        AddAttribute("src", src);
+        return this;
+    }
+
+    public Track SetKind(TrackKind kind)
+    {
+        Kind = kind;
+        AddAttribute("kind", kind.ToString().ToLower());
+        return this;
+    }
+
+    public Track SetSrclang(string srclang)
+    {
+        Srclang = srclang;
+        AddAttribute("srclang", srclang);
+        return this;
+    }
+
+    public Track SetLabel(string label)
+    {
+        Label = label;
+        AddAttribute("label", label);
+        return this;
+    }
+
+    public Track SetDefault()
+    {
+        IsDefault = true;
+        AddAttribute("default");
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/MediaTags/Video.cs
+++ b/src/HtmlBuilder/Tags/MediaTags/Video.cs
@@ -1,0 +1,63 @@
+﻿namespace HtmlBuilder.Tags.MediaTags;
+
+public class Video() : DoubleTagWithChildren("video")
+{
+    public string Src { get; private set; } = string.Empty;
+    public bool Controls { get; private set; } = false;
+    public bool Autoplay { get; private set; } = false;
+    public bool Loop { get; private set; } = false;
+    public bool Muted { get; private set; } = false;
+    public string Width { get; private set; }
+    public string Height { get; private set; }
+
+    public Video SetSrc(string src)
+    {
+        this.Src = src;
+        this.AddAttribute("src", src);
+        return this;
+    }
+
+    public Video SetControls()
+    {
+        this.Controls = true;
+        this.AddAttribute("controls");
+        return this;
+    }
+
+    public Video SetAutoplay()
+    {
+        this.Autoplay = true;
+        this.AddAttribute("autoplay");
+        return this;
+    }
+
+    public Video SetLoop()
+    {
+        this.Loop = true;
+        this.AddAttribute("loop");
+        return this;
+    }
+
+    public Video SetMuted()
+    {
+        this.Muted = true;
+        this.AddAttribute("muted");
+        return this;
+    }
+
+    public Video SetWidth(string width)
+    {
+        this.Width = width;
+        this.AddAttribute("width", width);
+        return this;
+    }
+
+    public Video SetHeight(string height)
+    {
+        this.Height = height;
+        this.AddAttribute("height", height);
+        return this;
+    }
+
+
+}

--- a/src/HtmlBuilder/Tags/ScriptAndMetaTags/Base.cs
+++ b/src/HtmlBuilder/Tags/ScriptAndMetaTags/Base.cs
@@ -1,0 +1,23 @@
+﻿using HtmlBuilder.Enums;
+
+namespace HtmlBuilder.Tags.ScriptAndMetaTags;
+
+public class Base() : SingleTag("base")
+{
+    public string Href { get; private set; } = string.Empty;
+    public BaseTarget Target { get; private set; } = BaseTarget._self;
+
+    public Base SetHref(string href)
+    {
+        this.Href = href;
+        this.AddAttribute("href", href);
+        return this;
+    }
+
+    public Base SetTarget(BaseTarget target)
+    {
+        this.Target = target;
+        this.AddAttribute("target", target.ToString().ToLower());
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/ScriptAndMetaTags/Link.cs
+++ b/src/HtmlBuilder/Tags/ScriptAndMetaTags/Link.cs
@@ -1,0 +1,26 @@
+﻿namespace HtmlBuilder.Tags.ScriptAndMetaTags;
+
+public class Link() : SingleTag("link")
+{
+    public string Rel { get; private set; } = string.Empty;
+    public string Type { get; private set; } = "text/css";
+    public string Href { get; private set; } = string.Empty;
+    public Link SetRel(string rel)
+    {
+        this.Rel = rel;
+        this.AddAttribute("rel", rel);
+        return this;
+    }
+    public Link SetType(string type)
+    {
+        this.Type = type;
+        this.AddAttribute("type", type);
+        return this;
+    }
+    public Link SetHref(string href)
+    {
+        this.Href = href;
+        this.AddAttribute("href", href);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/ScriptAndMetaTags/Meta.cs
+++ b/src/HtmlBuilder/Tags/ScriptAndMetaTags/Meta.cs
@@ -1,0 +1,35 @@
+﻿namespace HtmlBuilder.Tags.ScriptAndMetaTags;
+
+public class Meta() : SingleTag("meta")
+{
+    public string MetaName { get; private set; } = string.Empty;
+    public string Content { get; private set; } = string.Empty;
+    public string HttpEquiv { get; private set; } = string.Empty;
+    public string Charset { get; private set; } = string.Empty;
+
+
+    public Meta SetName(string name)
+    {
+        this.MetaName = name;
+        this.AddAttribute("name", name);
+        return this;
+    }
+    public Meta SetContent(string content)
+    {
+        this.Content = content;
+        this.AddAttribute("content", content);
+        return this;
+    }
+    public Meta SetHttpEquiv(string httpEquiv)
+    {
+        this.HttpEquiv = httpEquiv;
+        this.AddAttribute("http-equiv", httpEquiv);
+        return this;
+    }
+    public Meta SetCharset(string charset)
+    {
+        this.Charset = charset;
+        this.AddAttribute("charset", charset);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/ScriptAndMetaTags/Noscript.cs
+++ b/src/HtmlBuilder/Tags/ScriptAndMetaTags/Noscript.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.ScriptAndMetaTags;
+
+public class Noscript() : DoubleTagWithChildren("noscript");

--- a/src/HtmlBuilder/Tags/ScriptAndMetaTags/Script.cs
+++ b/src/HtmlBuilder/Tags/ScriptAndMetaTags/Script.cs
@@ -1,0 +1,38 @@
+﻿namespace HtmlBuilder.Tags.ScriptAndMetaTags;
+
+public class Script() : DoubleTagWithContent("script")
+{
+    public string Src { get; private set; } = string.Empty;
+    public string type { get; private set; } = "text/javascript";
+    public bool IsAsync { get; private set; } = false;
+    public bool IsDefer { get; private set; } = false;
+
+    public Script SetSrc(string src)
+    {
+        this.Src = src;
+        this.AddAttribute("src", src);
+        return this;
+    }
+
+    public Script SetType(string type)
+    {
+        this.type = type;
+        this.AddAttribute("type", type);
+        return this;
+    }
+
+    public Script SetAsync()
+    {
+        this.IsAsync = true;
+        this.AddAttribute("async");
+        return this;
+    }
+
+    public Script SetDefer()
+    {
+        this.IsDefer = true;
+        this.AddAttribute("defer");
+        return this;
+    }
+
+}

--- a/src/HtmlBuilder/Tags/ScriptAndMetaTags/Style.cs
+++ b/src/HtmlBuilder/Tags/ScriptAndMetaTags/Style.cs
@@ -1,0 +1,21 @@
+﻿namespace HtmlBuilder.Tags.ScriptAndMetaTags;
+
+public class Style() : DoubleTagWithContent("style")
+{
+    public string Type { get; private set; } = "text/css";
+    public string Media { get; private set; } = string.Empty;
+
+    public Style SetType(string type)
+    {
+        this.Type = type;
+        this.AddAttribute("type", type);
+        return this;
+    }
+
+    public Style SetMedia(string media)
+    {
+        this.Media = media;
+        this.AddAttribute("media", media);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/StylingTags/B.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/B.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class B() : DoubleTagWithContent("b");

--- a/src/HtmlBuilder/Tags/StylingTags/Em.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/Em.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class Em() : DoubleTagWithContent("em");

--- a/src/HtmlBuilder/Tags/StylingTags/I.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/I.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class I() : DoubleTagWithContent("i");

--- a/src/HtmlBuilder/Tags/StylingTags/Mark.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/Mark.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class Mark() : DoubleTagWithContent("mark");

--- a/src/HtmlBuilder/Tags/StylingTags/S.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/S.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class S() : DoubleTagWithContent("s");

--- a/src/HtmlBuilder/Tags/StylingTags/Small.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/Small.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class Small() : DoubleTagWithContent("small");

--- a/src/HtmlBuilder/Tags/StylingTags/Span.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/Span.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class Span() : DoubleTagWithChildren("span");

--- a/src/HtmlBuilder/Tags/StylingTags/Strong.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/Strong.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class Strong() : DoubleTagWithContent("strong");

--- a/src/HtmlBuilder/Tags/StylingTags/Sub.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/Sub.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class Sub() : DoubleTagWithContent("sub");

--- a/src/HtmlBuilder/Tags/StylingTags/Sup.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/Sup.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class Sup() : DoubleTagWithContent("sup");

--- a/src/HtmlBuilder/Tags/StylingTags/U.cs
+++ b/src/HtmlBuilder/Tags/StylingTags/U.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.StylingTags;
+
+public class U() : DoubleTagWithContent("u");

--- a/src/HtmlBuilder/Tags/TableTags/Caption.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Caption.cs
@@ -1,0 +1,3 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+
+public class Caption() : DoubleTagWithContent("caption");

--- a/src/HtmlBuilder/Tags/TableTags/Col.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Col.cs
@@ -1,0 +1,13 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+
+public class Col() : SingleTag("col")
+{
+    public int Span { get; private set; }
+
+    public Col SetSpan(int span)
+    {
+        this.Span = span;
+        this.AddAttribute("span", span.ToString());
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/TableTags/Colgroup.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Colgroup.cs
@@ -1,0 +1,12 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+
+public class Colgroup() : DoubleTagWithChildren("colgroup")
+{
+    public int Span { get; private set; }
+    public Colgroup SetSpan(int span)
+    {
+        this.Span = span;
+        this.AddAttribute("span", span.ToString());
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/TableTags/Table.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Table.cs
@@ -1,0 +1,22 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+public class Table() : DoubleTagWithChildren("table")
+{
+    public int Border { get; private set; }
+    public string Summary { get; private set; } = string.Empty;
+
+    public Table SetBorder(int border)
+    {
+        this.Border = border;
+        this.AddAttribute("border", border.ToString());
+        return this;
+    }
+
+    public Table SetSummary(string summary)
+    {
+        this.Summary = summary;
+        this.AddAttribute("summary", summary);
+        return this;
+    }
+
+}
+

--- a/src/HtmlBuilder/Tags/TableTags/Tbody.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Tbody.cs
@@ -1,0 +1,4 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+
+public class Tbody() : DoubleTagWithChildren("tbody");
+

--- a/src/HtmlBuilder/Tags/TableTags/Td.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Td.cs
@@ -1,0 +1,30 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+
+public class Td() : DoubleTagWithChildren("td")
+{
+    public int Colspan { get; private set; }
+    public int Rowspan { get; private set; }
+    public string Headers { get; private set; } = string.Empty;
+
+    public Td SetColspan(int colspan)
+    {
+        this.Colspan = colspan;
+        this.AddAttribute("colspan", colspan.ToString());
+        return this;
+    }
+
+    public Td SetRowspan(int rowspan)
+    {
+        this.Rowspan = rowspan;
+        this.AddAttribute("rowspan", rowspan.ToString());
+        return this;
+    }
+
+    public Td SetHeaders(string headers)
+    {
+        this.Headers = headers;
+        this.AddAttribute("headers", headers);
+        return this;
+    }
+}
+

--- a/src/HtmlBuilder/Tags/TableTags/Tfoot.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Tfoot.cs
@@ -1,0 +1,4 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+
+public class Tfoot() : DoubleTagWithChildren("tfoot");
+

--- a/src/HtmlBuilder/Tags/TableTags/Th.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Th.cs
@@ -1,0 +1,37 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+
+public class Th() : DoubleTagWithChildren("th")
+{
+    public int Colspan { get; private set; }
+    public int Rowspan { get; private set; }
+    public string Headers { get; private set; } = string.Empty;
+    public string Scope { get; private set; } = string.Empty;
+
+    public Th SetColspan(int colspan)
+    {
+        this.Colspan = colspan;
+        this.AddAttribute("colspan", colspan.ToString());
+        return this;
+    }
+
+    public Th SetRowspan(int rowspan)
+    {
+        this.Rowspan = rowspan;
+        this.AddAttribute("rowspan", rowspan.ToString());
+        return this;
+    }
+
+    public Th SetHeaders(string headers)
+    {
+        this.Headers = headers;
+        this.AddAttribute("headers", headers);
+        return this;
+    }
+
+    public Th SetScope(string scope)
+    {
+        this.Scope = scope;
+        this.AddAttribute("scope", scope);
+        return this;
+    }
+}

--- a/src/HtmlBuilder/Tags/TableTags/Thead.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Thead.cs
@@ -1,0 +1,2 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+public class Thead() : DoubleTagWithChildren("thead");

--- a/src/HtmlBuilder/Tags/TableTags/Tr.cs
+++ b/src/HtmlBuilder/Tags/TableTags/Tr.cs
@@ -1,0 +1,2 @@
+﻿namespace HtmlBuilder.Tags.TableTags;
+public class Tr() : DoubleTagWithChildren("tr");

--- a/src/HtmlBuilder/Tags/TextContentTag/Hr.cs
+++ b/src/HtmlBuilder/Tags/TextContentTag/Hr.cs
@@ -1,3 +1,3 @@
-namespace HtmlBuilder.Tags.TextContentTag;
+﻿namespace HtmlBuilder.Tags.TextContentTag;
 
 public class Hr() : SingleTag("hr");

--- a/src/HtmlBuilder/TrackKind.cs
+++ b/src/HtmlBuilder/TrackKind.cs
@@ -1,0 +1,9 @@
+﻿namespace HtmlBuilder;
+public enum TrackKind
+{
+    Subtitles,
+    Captions,
+    Descriptions,
+    Chapters,
+    Metadata
+}


### PR DESCRIPTION
Add new classes and enums for HTML elements

This commit introduces several new classes and enumerations to the `HtmlBuilder` namespace, including the `ATarget` enum for anchor targets and various interactive, media, and styling tag classes. The project structure was updated by removing certain folder references in the `HtmlBuilder.csproj` file, and namespace declarations were revised for consistency across the new additions.

#### PR Classification
New feature implementation and code organization.

#### PR Summary
This pull request introduces new enums and classes for HTML elements, updates namespaces, and removes unnecessary project folders. 
- `ATarget.cs`: Renamed `AnchorTarget` to `ATarget` and preserved documentation.
- `ButtonType.cs`: Added a new `ButtonType` enum with various button types.
- `Button.cs`: Introduced a new `Button` class with properties and methods for managing button attributes.
- New classes for `Details`, `Dialog`, `Menu`, `Audio`, `Iframe`, `Img`, `Source`, `Track`, and `Video` have been added, each with specific properties and methods.
- `TrackKind.cs`: Added a new enum defining various track types.
